### PR TITLE
Add Chapter 04: Pattern Matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This repository uses these two packages:
 
 - [x] Basic Types
 - [x] Lists and Tuples
-- [ ] Pattern Matching
+- [x] Pattern Matching
 - [ ] `case`, `cond`, and `if`
 - [ ] Anonymous Functions
 - [ ] Binaries, Strings, and Charlists

--- a/lib/basic_types.ex
+++ b/lib/basic_types.ex
@@ -69,7 +69,9 @@ defmodule BasicTypes do
   @spec check_strict_boolean(boolean()) :: String.t()
   def check_strict_boolean(boolean) do
     or_result = boolean or "second_argument_executed"
+
     and_result = boolean and "second_argument_executed"
+
     not_result = not boolean
 
     """
@@ -85,7 +87,9 @@ defmodule BasicTypes do
   @spec check_boolean(boolean()) :: String.t()
   def check_boolean(expression) do
     or_result = expression || "second_argument_executed"
+
     and_result = expression && "second_argument_executed"
+
     not_result = !expression
 
     """

--- a/lib/list_and_tuples.ex
+++ b/lib/list_and_tuples.ex
@@ -62,8 +62,9 @@ defmodule ListAndTuples do
   """
   @spec determine_head_and_tail_list(list()) :: :ok
   def determine_head_and_tail_list(list) do
-    IO.inspect(hd(list))
-    IO.inspect(tl(list))
+    list |> hd() |> IO.inspect(label: "Head")
+
+    list |> tl() |> IO.inspect(label: "Tail")
 
     :ok
   end

--- a/lib/pattern_matching.ex
+++ b/lib/pattern_matching.ex
@@ -1,0 +1,95 @@
+defmodule PatternMatching do
+  @moduledoc """
+  Section Elixir Documentation #04 - Pattern Matching
+  """
+
+  @doc """
+  Tuple pattern match
+
+  ## Examples
+    iex> PatternMatching.tuple_match({:ok, 200, "Data fetched successfully"})
+    "Status: ok, Code: 200, Body: Data fetched successfully"
+  """
+  @spec tuple_match(tuple()) :: String.t()
+  def tuple_match(tuple) do
+    {status, code, body} = tuple
+
+    "Status: #{status}, Code: #{code}, Body: #{body}"
+  end
+
+  @doc """
+  Tagged tuple pattern match
+
+  ## Examples
+    iex> PatternMatching.tagged_tuple_match({:ok, 200, "Data fetched successfully"})
+    "Status: ok, Code: 200, Body: Data fetched successfully"
+  """
+  @spec tagged_tuple_match(tuple()) :: String.t()
+  def tagged_tuple_match({status, code, body}) do
+    {:ok, _, _} = {status, code, body}
+
+    "Status: ok, Code: #{code}, Body: #{body}"
+  end
+
+  @doc """
+  List pattern match
+
+  ## Examples
+    iex> PatternMatching.list_match(["SnSV ROG Laptop", 3200, "Electronic"])
+    "Brand: SnSV ROG Laptop, Price: 3200, Category: Electronic"
+  """
+  @spec list_match(list()) :: String.t()
+  def list_match([brand, price, category]) do
+    "Brand: #{brand}, Price: #{price}, Category: #{category}"
+  end
+
+  @doc """
+  Head and tail list pattern match
+
+  ## Examples
+    iex> PatternMatching.head_and_tail_list_match(["SnSV ROG Laptop", 3200, "Electronic"])
+    :ok
+  """
+  @spec head_and_tail_list_match(list()) :: :ok
+  def head_and_tail_list_match(list) do
+    [head | tail] = list
+
+    IO.inspect(head, label: "Head")
+
+    IO.inspect(tail, label: "Tail")
+
+    :ok
+  end
+
+  @doc """
+  Pin operator in tuple pattern match
+
+  ## Examples
+    iex> PatternMatching.pin_operator_in_tuple_match(:ok, {:ok, 200, "Data fetched successfully"})
+    :ok
+  """
+  @spec pin_operator_in_tuple_match(any(), tuple()) :: :ok
+  def pin_operator_in_tuple_match(pinned_value, {status, code, body}) do
+    {^pinned_value, _, _} = {status, code, body}
+
+    IO.inspect(pinned_value, label: "Pinned Value")
+
+    :ok
+  end
+
+  @doc """
+  Pin operator in list pattern match
+
+  ## Examples
+    iex> PatternMatching.pin_operator_in_list_match("SnSV ROG Laptop", ["SnSV ROG Laptop", 3200, "Electronic"])
+    :ok
+  """
+  @spec pin_operator_in_list_match(any(), list()) :: :ok
+  def pin_operator_in_list_match(pinned_value, tuple) do
+    [^pinned_value | _] = tuple
+
+    IO.inspect(pinned_value, label: "Pinned Value")
+
+    :ok
+  end
+end

--- a/test/pattern_matching_test.exs
+++ b/test/pattern_matching_test.exs
@@ -1,0 +1,45 @@
+defmodule PatternMatchingTest do
+  use ExUnit.Case, async: true
+
+  doctest PatternMatching
+
+  describe "PatternMatching.tuple_match/1" do
+    test "should return interoplated string from match variable" do
+      assert PatternMatching.tuple_match({:ok, 200, "Data fetched successfully"}) ===
+               "Status: ok, Code: 200, Body: Data fetched successfully"
+    end
+  end
+
+  describe "PatternMatching.tagged_tuple_match/1" do
+    test "should return interoplated string from match variable" do
+      assert PatternMatching.tagged_tuple_match({:ok, 200, "Data fetched successfully"}) ===
+               "Status: ok, Code: 200, Body: Data fetched successfully"
+    end
+  end
+
+  describe "PatternMatching.list_match/1" do
+    test "should return interoplated string from match variable" do
+      assert PatternMatching.list_match(["SnSV ROG Laptop", 3200, "Electronic"]) ===
+               "Brand: SnSV ROG Laptop, Price: 3200, Category: Electronic"
+    end
+  end
+
+  describe "PatternMatching.head_and_tail_list_match/1" do
+    test "should return head and tail output ending with :ok" do
+      assert PatternMatching.head_and_tail_list_match(["SnSV ROG Laptop", 3200, "Electronic"]) === :ok
+    end
+  end
+
+  describe "PatternMatching.pin_operator_in_tuple_match/2" do
+    test "should return pinned variable and tuple output ending with :ok" do
+      assert PatternMatching.pin_operator_in_tuple_match(:ok, {:ok, 200, "Data fetched successfully"}) === :ok
+    end
+  end
+
+  describe "PatternMatching.pin_operator_in_list_match/2" do
+    test "should return pinned variable and list output ending with :ok" do
+      assert PatternMatching.pin_operator_in_list_match("SnSV ROG Laptop", ["SnSV ROG Laptop", 3200, "Electronic"]) ===
+               :ok
+    end
+  end
+end


### PR DESCRIPTION
Adding some test functions in Chapter 04 to play around with pattern matching:

- `tuple_match/1` — basic tuple matching
- `tagged_tuple_match/1` — tagged tuple matching
- `list_match/1` — list matching basics
- `head_and_tail_list_match/1` — matching head and tail in lists
- `pin_operator_in_tuple_match/1` and `pin_operator_in_list_match/1` — using the pin operator in matching
